### PR TITLE
add class validation handler

### DIFF
--- a/src/main/java/com/rackspace/salus/test/WebTestUtils.java
+++ b/src/main/java/com/rackspace/salus/test/WebTestUtils.java
@@ -32,6 +32,7 @@ public class WebTestUtils {
    * The default Spring Boot error handler is not registered when using {@link MockMvc},
    * so this custom {@link ResultMatcher} encapsulates validation of the resolved exception
    * of the MVC result.
+   * Note that this only works for field validations, not class validations
    * <p>
    *   The following is an example of how this result matcher can be used:
    * </p>
@@ -67,6 +68,30 @@ public class WebTestUtils {
     };
   }
 
+  /**
+   * Checks the error message returned by a class validation failure.
+   * Note that this only works for class validations, not field validations
+   * <p>
+   *   The following is an example of how this result matcher can be used:
+   * </p>
+   * <pre>
+   DetailedMonitorInput create = setupCreateMonitorTest();
+   create.setDetails(new LocalMonitorDetails().setPlugin(new Mem()))
+   .setLabelSelector(null)
+   .setResourceId("");
+
+   mockMvc.perform(post(url)
+   .content(objectMapper.writeValueAsString(create))
+   .contentType(MediaType.APPLICATION_JSON)
+   .characterEncoding(StandardCharsets.UTF_8.name()))
+   .andExpect(status().isBadRequest())
+   .andExpect(classValidationError(ValidCreateMonitor.DEFAULT_MESSAGE));
+
+   * </pre>
+   *
+   * @param expectedMessage the expected default message of the failed validation
+   * @return the {@link ResultMatcher}
+   */
   public static ResultMatcher classValidationError(String expectedMessage) {
     return mvcResult -> {
       assertThat(mvcResult.getResolvedException())

--- a/src/main/java/com/rackspace/salus/test/WebTestUtils.java
+++ b/src/main/java/com/rackspace/salus/test/WebTestUtils.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultMatcher;
+import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 
@@ -64,6 +65,17 @@ public class WebTestUtils {
           .getFieldError();
       assertThat(fieldError.getDefaultMessage()).isEqualTo(expectedMessage);
       assertThat(fieldError.getField()).isEqualTo(expectedField);
+    };
+  }
+
+  public static ResultMatcher classValidationError(String expectedMessage) {
+    return mvcResult -> {
+      assertThat(mvcResult.getResolvedException())
+          .isInstanceOf(MethodArgumentNotValidException.class);
+
+      final String actualMessage = ((MethodArgumentNotValidException) mvcResult
+          .getResolvedException()).getMessage();
+      assertThat(actualMessage).contains(expectedMessage);
     };
   }
 }

--- a/src/main/java/com/rackspace/salus/test/WebTestUtils.java
+++ b/src/main/java/com/rackspace/salus/test/WebTestUtils.java
@@ -20,7 +20,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultMatcher;
-import org.springframework.validation.BindingResult;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 


### PR DESCRIPTION
# Resolves

used for: https://jira.rax.io/browse/SALUS-494

# What

We have a handler for field validation errors, but it doesn't work on class validations.  This PR adds that function.
